### PR TITLE
Fix small API and Gemini bugs

### DIFF
--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   const chats = await Chat.find({ user: session.user.id }).sort({ updatedAt: -1 });
   const response = chats.map((chat: any) => ({
     id: chat._id.toString(),
-    title: chat.title || "Untitled Chat",
+    title: chat.chatTitle || "Untitled Chat",
   }));
 
   return NextResponse.json(response);
@@ -37,5 +37,5 @@ export async function POST(req: NextRequest) {
     suggestions: [],
   });
 
-  return NextResponse.json({ id: chat._id.toString(), title: chat.title });
+  return NextResponse.json({ id: chat._id.toString(), title: chat.chatTitle });
 }

--- a/lib/geminiClient.ts
+++ b/lib/geminiClient.ts
@@ -33,7 +33,7 @@ export async function getFollowupReply(prompt: string): Promise<string> {
     const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
     const result = await model.generateContent(prompt);
     const response = await result.response;
-    const text = response.text();
+    const text = await response.text();
     return text.trim();
   } catch (err) {
     console.error("Gemini follow-up reply error:", err);


### PR DESCRIPTION
## Summary
- fix missing await for Gemini followup reply
- correct property name in chats API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684042472b088328a0d6159effac6cec